### PR TITLE
feat: block custom props

### DIFF
--- a/packages/smooth/src/content/Blocks.js
+++ b/packages/smooth/src/content/Blocks.js
@@ -52,13 +52,20 @@ export const BlockFragment = gql`
   ${blocks.map(block => getFragmentString(block.fragment)).join('')}
 `
 
-export function Blocks({ blocks: blocksProp }) {
+export function Blocks({ blocks: blocksProp, ...other }) {
   if (!blocksProp) return null
   return blocksProp.map(({ type, ...props }, index) => {
     const block = blocksByType[type]
     if (!block) {
       throw new Error(`Block "${type}" is not found`)
     }
-    return <block.Component key={index} {...props[block.propsAttribute]} />
+
+    return (
+      <block.Component
+        key={index}
+        {...props[block.propsAttribute]}
+        {...other}
+      />
+    )
   })
 }


### PR DESCRIPTION
User should be able to pass custom props to blocks. The original use case is the need to distinguish between layouts (display a block depending on the type of post).