### PR TITLE
feat: Add custom hreflang links for HeadMeta component

### DIFF
--- a/packages/smooth-plugin-head-meta/src/definitions/HeadMeta.js
+++ b/packages/smooth-plugin-head-meta/src/definitions/HeadMeta.js
@@ -33,6 +33,6 @@ export const typeDefs = gql`
     twitterDescription: String @field(label: "Twitter description")
     twitterImage: Image @field(label: "Twitter image")
     customMetas: [CustomMeta] @field(label: "Custom metadatas")
-    HreflangLinks: [HreflangLink] @field(label: "hreflang links")
+    hreflangLinks: [HreflangLink] @field(label: "hreflang links")
   }
 `

--- a/packages/smooth-plugin-head-meta/src/definitions/HeadMeta.js
+++ b/packages/smooth-plugin-head-meta/src/definitions/HeadMeta.js
@@ -11,7 +11,7 @@ export const typeDefs = gql`
     content: String @field(label: "Content")
   }
 
-  type customHreflangLink {
+  type HreflangLink {
     rel: String @field(label: "rel")
     href: String @field(label: "href")
     hreflang: String @field(label: "hreflang")
@@ -33,7 +33,6 @@ export const typeDefs = gql`
     twitterDescription: String @field(label: "Twitter description")
     twitterImage: Image @field(label: "Twitter image")
     customMetas: [CustomMeta] @field(label: "Custom metadatas")
-    customHreflangLinks: [customHreflangLink]
-      @field(label: "Custom hreflang links")
+    HreflangLinks: [HreflangLink] @field(label: "hreflang links")
   }
 `

--- a/packages/smooth-plugin-head-meta/src/definitions/HeadMeta.js
+++ b/packages/smooth-plugin-head-meta/src/definitions/HeadMeta.js
@@ -11,6 +11,12 @@ export const typeDefs = gql`
     content: String @field(label: "Content")
   }
 
+  type customHreflangLink {
+    rel: String @field(label: "rel")
+    href: String @field(label: "href")
+    hreflang: String @field(label: "hreflang")
+  }
+
   type HeadMeta {
     title: String @field(label: "Title")
     description: String @field(label: "Description")
@@ -27,5 +33,7 @@ export const typeDefs = gql`
     twitterDescription: String @field(label: "Twitter description")
     twitterImage: Image @field(label: "Twitter image")
     customMetas: [CustomMeta] @field(label: "Custom metadatas")
+    customHreflangLinks: [customHreflangLink]
+      @field(label: "Custom hreflang links")
   }
 `

--- a/packages/smooth-plugin-head-meta/src/smooth-browser.js
+++ b/packages/smooth-plugin-head-meta/src/smooth-browser.js
@@ -37,8 +37,8 @@ function HeadMeta({ headMeta }) {
         headMeta.customMetas.map((meta, index) => (
           <meta key={index} name={meta.name} content={meta.content} />
         ))}
-      {headMeta.customHreflangLinks &&
-        headMeta.customHreflangLinks.map((link, index) => (
+      {headMeta.hreflangLinks &&
+        headMeta.hreflangLinks.map((link, index) => (
           <link
             key={index}
             rel={link.rel}
@@ -82,7 +82,7 @@ headMeta {
     name
     content
   }
-  customHreflangLinks {
+  hreflangLinks {
     rel
     href
     hreflang

--- a/packages/smooth-plugin-head-meta/src/smooth-browser.js
+++ b/packages/smooth-plugin-head-meta/src/smooth-browser.js
@@ -37,6 +37,15 @@ function HeadMeta({ headMeta }) {
         headMeta.customMetas.map((meta, index) => (
           <meta key={index} name={meta.name} content={meta.content} />
         ))}
+      {headMeta.customHreflangLinks &&
+        headMeta.customHreflangLinks.map((link, index) => (
+          <link
+            key={index}
+            rel={link.rel}
+            href={link.href}
+            hrefLang={link.hreflang}
+          />
+        ))}
     </Helmet>
   )
 }
@@ -72,6 +81,11 @@ headMeta {
   customMetas {
     name
     content
+  }
+  customHreflangLinks {
+    rel
+    href
+    hreflang
   }
 }
   `,


### PR DESCRIPTION
This PR adds custom links on Helmet to configure hreflang links.
It's a SEO requirement for i18n optimizations.