### PR TITLE
fix: error middleware in onCreateServer hook

### DIFF
--- a/packages/smooth/src/server/expressApp.js
+++ b/packages/smooth/src/server/expressApp.js
@@ -67,6 +67,8 @@ export function createExpressApp({
 
   app.use(ssr({ config, schema, fragmentTypes }))
 
+  onCreateServer(config)({ app })
+
   if (config.env === 'development') {
     app.use((error, req, res, next) => {
       const graphQLErrors =


### PR DESCRIPTION
Hi,

In plugins, for node, in `onCreateServer` hook, if we define an error middleware, it is never triggered: 

```
export function onCreateServer({ app }) {
   app.use((err, req, res, next) => {
      // Never triggered
       logError(err)
       next(err)
   })
}
```

We must add another hook call just after the SSR middleware in express init file `expressApp.js` to have the capability to get errors in error middleware.