### PR TITLE
doc(plugin): hook wrapRootElement is in smooth-node.js

### DIFF
--- a/packages/smooth/README.md
+++ b/packages/smooth/README.md
@@ -903,13 +903,13 @@ The `modules` option on `"preset-env"` should be kept to `false` otherwise webpa
 - getContents
 - getContent
 - onBuild
+- wrapRootElement
 
 ### smooth-browser.js
 
 - onRouteUpdate
 - onSelectContentFields
 - wrapContentElement
-- wrapRootElement
 
 ## Production deployment
 


### PR DESCRIPTION
Hi,

Just a small mistake in the documentation, `wrapRootElement` belong to node hooks not to browser ones.