### PR TITLE
fix(graphql): Cannot read property '0' of undefined

### DIFF
--- a/packages/smooth-backend-wordpress/src/acf/api.js
+++ b/packages/smooth-backend-wordpress/src/acf/api.js
@@ -58,8 +58,8 @@ export function createClient({
     },
 
     async getContent(request) {
-      const { data } = await this.getContents(request)
-      return data[0] || null
+      const { data = []} = await this.getContents(request)
+      return data && data[0] || null
     },
 
     async getContentPreview({ lang, id }) {


### PR DESCRIPTION
In case you use WPLM plugins in wordpress. If you start with a page Fench then a page translated into English but must remain in draft (the page does not contain slug).
So we come across a graphql bug related to the error:
TypeError: Can not read property '0' of undefined
    at Object.getContent (/../node_modules/smooth-backend-wordpress/lib/acf/api.js:113:18)
    at processTicksAndRejections (internal / process / task_queues.js: 93: 5)
    at async Promise.all (index 0)


Or data should always be an array.