### PR TITLE
Fix PHP Warning 'use of undefined constant icl_object_id'

### DIFF
--- a/packages/smooth-backend-wordpress/src/wordpress/plugin/index.php
+++ b/packages/smooth-backend-wordpress/src/wordpress/plugin/index.php
@@ -149,7 +149,7 @@ function get_content($data)
 	$slug = $data['slug'];
 	$lang = $data['lang'];
 	$post = get_page_by_path($slug, OBJECT, $postType);
-	if ($lang && function_exists(icl_object_id)) {
+	if ($lang && function_exists('icl_object_id')) {
 		$post = get_page(icl_object_id($post->ID, $postType, true, $lang));
 	}
 	if (!$post) {


### PR DESCRIPTION
We have a warning when a constant is not quoted :

wordpress_1  | [Tue Nov 12 16:37:40.085403 2019] [php7:warn] [pid 83] [client 172.19.0.1:39970] PHP Warning:  Use of undefined constant icl_object_id - assumed 'icl_object_id' (this will throw an Error in a future version of PHP) in /var/www/html/wp-content/plugins/smooth-js/index.php on line 152