### PR TITLE
fix: add check if rel in hreflanglink is null

### DIFF
--- a/packages/smooth-plugin-head-meta/src/smooth-browser.js
+++ b/packages/smooth-plugin-head-meta/src/smooth-browser.js
@@ -38,14 +38,17 @@ function HeadMeta({ headMeta }) {
           <meta key={index} name={meta.name} content={meta.content} />
         ))}
       {headMeta.hreflangLinks &&
-        headMeta.hreflangLinks.map((link, index) => (
-          <link
-            key={index}
-            rel={link.rel}
-            href={link.href}
-            hrefLang={link.hreflang}
-          />
-        ))}
+        headMeta.hreflangLinks.map(
+          (link, index) =>
+            link.rel && (
+              <link
+                key={index}
+                rel={link.rel}
+                href={link.href}
+                hrefLang={link.hreflang}
+              />
+            ),
+        )}
     </Helmet>
   )
 }

--- a/packages/smooth-plugin-head-meta/src/smooth-browser.js
+++ b/packages/smooth-plugin-head-meta/src/smooth-browser.js
@@ -38,17 +38,14 @@ function HeadMeta({ headMeta }) {
           <meta key={index} name={meta.name} content={meta.content} />
         ))}
       {headMeta.hreflangLinks &&
-        headMeta.hreflangLinks.map(
-          (link, index) =>
-            link.rel && (
-              <link
-                key={index}
-                rel={link.rel}
-                href={link.href}
-                hrefLang={link.hreflang}
-              />
-            ),
-        )}
+        headMeta.hreflangLinks.map((link, index) => (
+          <link
+            key={index}
+            rel={link.rel || ''}
+            href={link.href}
+            hrefLang={link.hreflang}
+          />
+        ))}
     </Helmet>
   )
 }


### PR DESCRIPTION
If a hreflanglink has it's field `rel` set to null, the page crash with an `react-helmet` error.

The `react-helmet` error:
```
"TypeError: Cannot read property 'toLowerCase' of null
    at /usr/src/app/node_modules/react-helmet/lib/Helmet.js:246:264
    at Array.filter (<anonymous>)
    at /usr/src/app/node_modules/react-helmet/lib/Helmet.js:238:22
    at Array.reduce (<anonymous>)
    at getTagsFromPropsList (/usr/src/app/node_modules/react-helmet/lib/Helmet.js:235:18)
    at reducePropsToState (/usr/src/app/node_modules/react-helmet/lib/Helmet.js:311:19)
    at emitChange (/usr/src/app/node_modules/react-side-effect/lib/index.js:56:15)
    at SideEffect.UNSAFE_componentWillMount (/usr/src/app/node_modules/react-side-effect/lib/index.js:97:9)
    at d (/usr/src/app/node_modules/react-dom/cjs/react-dom-server.node.production.min.js:37:457)
    at $a (/usr/src/app/node_modules/react-dom/cjs/react-dom-server.node.production.min.js:39:16)"
```
